### PR TITLE
fix: fold cast null to typed null

### DIFF
--- a/datafusion/substrait/src/logical_plan/producer.rs
+++ b/datafusion/substrait/src/logical_plan/producer.rs
@@ -1573,6 +1573,21 @@ pub fn from_cast(
     schema: &DFSchemaRef,
 ) -> Result<Expression> {
     let Cast { expr, data_type } = cast;
+    // since substrait Null must be typed, so if we see a cast(null, dt), we make it a typed null
+    if let Expr::Literal(lit) = expr.as_ref() {
+        if lit.is_null() {
+            let lit = Literal {
+                nullable: true,
+                type_variation_reference: DEFAULT_TYPE_VARIATION_REF,
+                literal_type: Some(LiteralType::Null(to_substrait_type(
+                    &data_type, true,
+                )?)),
+            };
+            return Ok(Expression {
+                rex_type: Some(RexType::Literal(lit)),
+            });
+        }
+    }
     Ok(Expression {
         rex_type: Some(RexType::Cast(Box::new(
             substrait::proto::expression::Cast {


### PR DESCRIPTION
# Which issue does this PR close?

 # Rationale for this change

fix `SELECT NULL::DOUBLE` can't be encode to substrait error

# What changes are included in this PR?
fold `cast(NULL, <data type>` to typed null in substrait

# Are there any user-facing changes?
nil